### PR TITLE
Use previous Alpine version for PHP 8.1 tag

### DIFF
--- a/php8.1/Dockerfile
+++ b/php8.1/Dockerfile
@@ -1,4 +1,5 @@
-FROM php:8.1-fpm-alpine3.15
+FROM php:8.1-fpm-alpine3.14
+# Alpine 3.15 upgrades Node to 16. Some downstream bits that use `apk` to add Node are not ready for this yet.
 
 ENV PATH "$PATH:/var/www/html/vendor/bin"
 


### PR DESCRIPTION
Alpine 3.15 upgrades Node to 16. Some downstream bits that use `apk` to add Node are not ready for this yet.

See:
* https://alpinelinux.org/posts/Alpine-3.14.0-released.html
* https://alpinelinux.org/posts/Alpine-3.15.0-released.html